### PR TITLE
[Feat/#3] course and semester(complete creating dao) 

### DIFF
--- a/swe/src/main/java/com/kwu/swe/domain/course/entity/Course.java
+++ b/swe/src/main/java/com/kwu/swe/domain/course/entity/Course.java
@@ -1,0 +1,20 @@
+package com.kwu.swe.domain.course.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Course {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "course_id")
+    private Long id;
+
+    private String courseName;
+    private String courseNumber;
+    private int score;
+}

--- a/swe/src/main/java/com/kwu/swe/domain/course/repository/CourseRepository.java
+++ b/swe/src/main/java/com/kwu/swe/domain/course/repository/CourseRepository.java
@@ -1,0 +1,7 @@
+package com.kwu.swe.domain.course.repository;
+
+import com.kwu.swe.domain.course.entity.Course;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CourseRepository extends JpaRepository<Course, Long> {
+}

--- a/swe/src/main/java/com/kwu/swe/domain/lecture/entity/Lecture.java
+++ b/swe/src/main/java/com/kwu/swe/domain/lecture/entity/Lecture.java
@@ -1,5 +1,6 @@
 package com.kwu.swe.domain.lecture.entity;
 
+import com.kwu.swe.domain.course.entity.Course;
 import jakarta.persistence.*;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
@@ -21,4 +22,16 @@ public class Lecture {
     @Enumerated(EnumType.STRING)
     @Column(name = "lecture_status", nullable = false)
     private LectureStatus lectureStatus;
+
+    @Enumerated
+    @Column(name = "semester", nullable = false, length = 50)
+    private Semester semester;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "lecture_schedule_id")
+    private LectureSchedule lectureSchedule;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "course_id")
+    private Course course;
 }

--- a/swe/src/main/java/com/kwu/swe/domain/lecture/entity/Lecture.java
+++ b/swe/src/main/java/com/kwu/swe/domain/lecture/entity/Lecture.java
@@ -17,4 +17,8 @@ public class Lecture {
     private Long id;
 
     private int sizeLimit;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "lecture_status", nullable = false)
+    private LectureStatus lectureStatus;
 }

--- a/swe/src/main/java/com/kwu/swe/domain/lecture/entity/Lecture.java
+++ b/swe/src/main/java/com/kwu/swe/domain/lecture/entity/Lecture.java
@@ -19,14 +19,18 @@ public class Lecture {
 
     private int sizeLimit;
 
+    //강의 전, 강의 중, 강의 후
+    //학점 부여를 위한 status
     @Enumerated(EnumType.STRING)
     @Column(name = "lecture_status", nullable = false)
     private LectureStatus lectureStatus;
 
+    //4개의 학기밖에 없으므로 entity -> enum으로 변경
     @Enumerated
     @Column(name = "semester", nullable = false, length = 50)
     private Semester semester;
 
+    //해당 강의의 스케줄 및 장소를 여러개 정할 수 있음
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "lecture_schedule_id")
     private LectureSchedule lectureSchedule;

--- a/swe/src/main/java/com/kwu/swe/domain/lecture/entity/LectureSchedule.java
+++ b/swe/src/main/java/com/kwu/swe/domain/lecture/entity/LectureSchedule.java
@@ -15,6 +15,7 @@ public class LectureSchedule {
     @Column(name = "lecture_schedule_id")
     private Long id;
 
+    //테이블 대신 이넘 연결
     @Enumerated
     @Column(name = "class_time", nullable = false)
     private ClassTime classTime;

--- a/swe/src/main/java/com/kwu/swe/domain/lecture/entity/LectureStatus.java
+++ b/swe/src/main/java/com/kwu/swe/domain/lecture/entity/LectureStatus.java
@@ -1,0 +1,15 @@
+package com.kwu.swe.domain.lecture.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum LectureStatus {
+
+    BEFORE("강의 전"),
+    IN_PROGRESS("강의 중"),
+    COMPLETED("강의 완료");
+
+    private final String key;
+}

--- a/swe/src/main/java/com/kwu/swe/domain/lecture/entity/Semester.java
+++ b/swe/src/main/java/com/kwu/swe/domain/lecture/entity/Semester.java
@@ -1,0 +1,16 @@
+package com.kwu.swe.domain.lecture.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Semester {
+
+    FIRST_SEMESTER("1학기"),
+    SECOND_SEMESTER("2학기"),
+    SUMMER("계절학기(하)"),
+    WINTER("게절학기(동)");
+
+    private final String key;
+}


### PR DESCRIPTION
- https://github.com/kwu-swe/kwu-swe-spring/issues/3

기존 entity 설계와는 조금 변형이 되었습니다.
1. semester 는 계절이 총 4개이며 하위 필드가 존재하지 않기 때문에 lecture의 enum으로 사용했습니다.
2. 마찬가지로 classTime도 테이블이 아닌 enum으로 둔 이유가 1번과 동일합니다.
3. 강의의 status 이넘을 추가했는데, 이는 학기가 종료되었을 때 수강중인 학생들에게 점수를 부여하기 위함입니다.